### PR TITLE
remove autosemver install dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     packages=['isbn'],
     package_dir={
         'isbn': 'isbn'},
-    install_requires=['autosemver~=0.2'],
+    install_requires=[],
     setup_requires=['autosemver~=0.2'],
     autosemver={
         'bugtracker_url': 'https://github.com/inspirehep/isbnid/issues'},


### PR DESCRIPTION
autosemver looks very useful for development, but it doesn't seem to be required for user installation.  Removing it will simplify installation for downstream projects like idutils.